### PR TITLE
let downloader be null

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,7 +151,9 @@ function TileSet(tileDir, options) {
         },
         downloader: new ImagicoElevationDownloader(tileDir)
     }, options);
-
+    if(options.downloader == undefined) {
+        this.options.downloader = undefined;
+    }
     this._tileDir = tileDir;
     this._tiles = {};
     this._loadingTiles = {};


### PR DESCRIPTION
extend() does not copy undefined values, so it is necessary to manually check if options.downloader == undefined to make it possible to not use a downloader.
Why would you want to not use a downloader? In my cases I have all of the available 1arcsecond SRTM data predownloaded, so so any data that isn't there is not available, and requesting it would just slow things down.
