### PR TITLE
Use lru-cache for storing tiles, instead of an array

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,7 +158,11 @@ function TileSet(tileDir, options) {
     this._tileDir = tileDir;
     this._tileCache = LRU({
         max: 1000,
-        dispose: function (key, n) { n.destroy() }
+        dispose: function (key, n) { 
+            if(n) {
+                n.destroy();
+            }
+        }
     });
     this._loadingTiles = {};
 }

--- a/index.js
+++ b/index.js
@@ -151,7 +151,9 @@ function TileSet(tileDir, options) {
         },
         downloader: new ImagicoElevationDownloader(tileDir)
     }, options);
-
+    if(options.downloader == undefined) {
+        this.options.downloader = undefined;
+    }
     this._tileDir = tileDir;
     this._tiles = {};
     this._loadingTiles = {};

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "mmap": "^2.0.2",
     "promise": "^6.1.0",
     "request": "^2.54.0",
-    "yauzl": "^2.2.1"
+    "yauzl": "^2.2.1",
+    "lru-cache": "^2.6.5"
   },
   "devDependencies": {
     "tap-spec": "^2.2.2",


### PR DESCRIPTION
I ran into a problem with my production elevation-service server, elevation lookups were randomly failing. After a bunch of debugging I determined that what was happening is that opening files was failing after 1024 were open due to limits on open file descriptors. My solution was to use an lru cache with a limit of 1000 items to store the tiles, instead of an array. Im not really sure if this is the right solution, but it works for me. Another option is to raise the file descriptor limit, but I don't know enough about node performance to know what the implications of mmaping thousands of files will be. There are approximately 19554 1 degree tiles that include some land between 80°S and 80°N.

I'm guessing you might not want to accept this PR, but I'm curious what your solution to this problem is.
