### PR TITLE
Replace mmap with mmap.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var fs = require('fs'),
     os = require('os'),
     util = require('util'),
     path = require('path'),
-    mmap = require('mmap'),
+    mmap = require('mmap.js'),
     Promise = require('promise'),
     request = require('request'),
     yauzl = require('yauzl'),
@@ -42,7 +42,7 @@ function Hgt(path, swLatLng, options) {
             throw new Error('Unknown tile format (1 arcsecond and 3 arcsecond supported).');
         }
 
-        this._buffer = mmap(stat.size, mmap.PROT_READ, mmap.MAP_SHARED, fd);
+        this._buffer = mmap.alloc(stat.size, mmap.PROT_READ, mmap.MAP_SHARED, fd);
         this._swLatLng = _latLng(swLatLng);
         this._fd = fd;
 
@@ -92,7 +92,6 @@ Hgt.bilinear = function(row, col) {
 };
 
 Hgt.prototype.destroy = function() {
-    this._buffer.unmap();
     fs.closeSync(this._fd);
     delete this._buffer;
 };
@@ -158,7 +157,7 @@ function TileSet(tileDir, options) {
     this._tileDir = tileDir;
     this._tileCache = LRU({
         max: 1000,
-        dispose: function (key, n) { 
+        dispose: function (key, n) {
             if(n) {
                 n.destroy();
             }

--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
   "license": "ISC",
   "dependencies": {
     "extend": "^2.0.0",
-    "mmap": "^2.0.2",
+    "lru-cache": "^2.6.5",
+    "mmap.js": "^1.0.0",
     "promise": "^6.1.0",
     "request": "^2.54.0",
-    "yauzl": "^2.2.1",
-    "lru-cache": "^2.6.5"
+    "yauzl": "^2.2.1"
   },
   "devDependencies": {
     "tap-spec": "^2.2.2",

--- a/test/hgt-spec.js
+++ b/test/hgt-spec.js
@@ -21,7 +21,7 @@ test('can query hgt nearestneighbour', function(t) {
     var hgt = new Hgt(__dirname + '/data/N57E011.hgt', [57, 11], {
         interpolation: Hgt.nearestNeighbour
     });
-    
+
     t.equal(hgt.getElevation([57, 11]), 0);
     t.equal(hgt.getElevation([57.7, 11.9]), 16);
     hgt.destroy();
@@ -32,7 +32,7 @@ test('can query hgt bilinear', function(t) {
     var hgt = new Hgt(__dirname + '/data/N57E011.hgt', [57, 11], {
         interpolation: Hgt.bilinear
     });
-    
+
     t.equal(hgt.getElevation([57, 11]), 0);
     almostEqual(t, hgt.getElevation([57.7, 11.9]), 16);
     hgt.destroy();


### PR DESCRIPTION
`mmap` errors out during compile on osx so I swapped it out for `mmap.js` who's slogan is "mmap bindings for node.js that work" so I guess this is a known issue.

Not sure if this is something you're interested in merging but I thought I would share it anyway!

Thanks for this library by the way - it makes this stuff so much more accessible!
